### PR TITLE
add Go 1.22 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         go:
+          - "1.22"
           - "1.21"
       fail-fast: false
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the testing framework to include Go version "1.22".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->